### PR TITLE
feat: Bump versions also on predefined non-master branches

### DIFF
--- a/deployhook.py
+++ b/deployhook.py
@@ -1,15 +1,25 @@
+import hashlib
+import hmac
 import os
+import re
 import tempfile
 import subprocess
 from contextlib import contextmanager
+
 from flask import Flask, request, jsonify
 
 
 app = Flask(__name__)
 
+IS_DEV = (app.env == 'development')
+
+# A list of regular expressions for branches that will be checked for new commits
+TRACKED_BRANCHES = [
+    r'^master$',
+    r'^auto-getsentry/.*$',
+]
 
 DEPLOY_REPO = 'git@github.com:getsentry/getsentry'
-DEPLOY_BRANCH = 'master'
 COMMITTER_NAME = 'Sentry Bot'
 COMMITTER_EMAIL = 'bot@getsentry.com'
 SSH_KEY = '''
@@ -49,12 +59,16 @@ PLUGIN_REPOS = [
     'getsentry/sentry-auth-github',
 ]
 
+GITHUB_WEBHOOK_SECRET = os.environ.get('GITHUB_WEBHOOK_SECRET')
+
 
 @contextmanager
 def ssh_environment():
     key_file = tempfile.mktemp()
     with open(key_file, 'w') as f:
         f.write(SSH_KEY)
+    os.chmod(key_file, 0600)
+
     exec_file = tempfile.mktemp()
     with open(exec_file, 'w') as f:
         f.write('''#!/bin/sh
@@ -64,36 +78,62 @@ def ssh_environment():
     yield exec_file
 
 
-def bump_version(script, *args):
+def bump_version(branch, script, *args):
     with ssh_environment() as ssh_executable:
         repo_root = tempfile.mkdtemp()
+
         def cmd(*args, **opts):
             opts.setdefault('cwd', repo_root)
             env = opts.setdefault('env', {})
             env['GIT_SSH'] = ssh_executable
             return subprocess.Popen(list(args), **opts).wait()
 
-        cmd('git', 'clone', '--depth', '1', '-b', DEPLOY_BRANCH,
-            DEPLOY_REPO, repo_root, cwd=None)
+        # the branch has to be created manually in DEPLOY_REPO
+        if cmd('git', 'clone', '--depth', '1', '-b', branch,
+               DEPLOY_REPO, repo_root, cwd=None) != 0:
+            return False, 'Cannot clone branch {} from {}.'.format(branch, DEPLOY_REPO)
+
         cmd('git', 'config', 'user.name', COMMITTER_NAME)
         cmd('git', 'config', 'user.email', COMMITTER_EMAIL)
         cmd(script, *args)
 
-        for x in xrange(5):
-            if cmd('git', 'push', 'origin', DEPLOY_BRANCH) == 0:
+        for _ in xrange(5):
+            if cmd('git', 'push', 'origin', branch) == 0:
                 break
-            cmd('git', 'pull', '--rebase', 'origin', DEPLOY_BRANCH)
+            cmd('git', 'pull', '--rebase', 'origin', branch)
 
-        return True, 'Executed: {}'.format(' '.join([script] + args))
+        return True, 'Executed: {}'.format(' '.join([script] + list(args)))
+
+
+def is_tracked_branch(branch):
+    return bool(list(
+        filter(lambda branch_regex: re.match(
+            branch_regex, branch), TRACKED_BRANCHES)
+    ))
 
 
 @app.route('/', methods=['POST'])
 def index():
-    branches = set('refs/heads/' + x for x in
-                   (request.args.get('branches') or 'master').split(','))
+    if not IS_DEV:
+        # Validate payload signature
+        signature = hmac.new(GITHUB_WEBHOOK_SECRET,
+                             request.data, hashlib.sha1).hexdigest()
+        if not hmac.compare_digest(signature, str(request.headers.get('X-Hub-Signature', '').replace('sha1=', ''))):
+            return jsonify(updated=False, reason='Cannot validate payload signature.')
+
+        if request.headers.get('X-GitHub-Event') != 'push':
+            return jsonify(updated=False, reason='Only "push" events are allowed.')
+
     data = request.get_json()
 
-    if data.get('ref') not in branches:
+    ref = data.get('ref')
+    prefix = 'refs/heads/'
+    if ref.startswith(prefix):
+        branch = ref[len(prefix):]
+    else:
+        return jsonify(updated=False, reason='Invalid "ref".')
+
+    if not is_tracked_branch(branch):
         return jsonify(updated=False,
                        reason='Commit against untracked branch.')
 
@@ -103,10 +143,10 @@ def index():
 
     if ref_sha is not None:
         if repo == 'getsentry/sentry':
-            updated, reason = bump_version('bin/bump-sentry', ref_sha)
+            updated, reason = bump_version(branch, 'bin/bump-sentry', ref_sha)
         elif repo in PLUGIN_REPOS:
             args = ['--repo', repo, ref_sha]
-            updated, reason = bump_version('bin/bump-plugins', *args)
+            updated, reason = bump_version(branch, 'bin/bump-plugins', *args)
         else:
             updated = False
             reason = 'Unknown repository'
@@ -118,3 +158,6 @@ def index():
 if not app.debug:
     import logging
     app.logger.addHandler(logging.StreamHandler())
+
+if not IS_DEV and not GITHUB_WEBHOOK_SECRET:
+    raise SystemError('Empty GITHUB_WEBHOOK_SECRET!')


### PR DESCRIPTION
The following features are added:
* Webhook signature + event type validation
* On commits to (sentry) branches prefixed with `auto-getsentry/`, we try to update the same branch in `getsentry` with the commit SHA