### PR TITLE
fix: Allow non-ascii chars in author data

### DIFF
--- a/deployhook.py
+++ b/deployhook.py
@@ -121,7 +121,7 @@ def process_push():
     author_name = author_data.get('name')
     author_email = author_data.get('email')
     if author_name and author_email:
-        author = "{} <{}>".format(author_name, author_email)
+        author = u"{} <{}>".format(author_name.decode('utf8'), author_email.decode('utf8'))
     else:
         author = None
 


### PR DESCRIPTION
I haaaate (read "always mess up") these string-unicode things in Python, so please confirm if this makes sense. 

`author` is later used as a script argument in a Popen call.