### PR TITLE
feat(dev): Add support for running flask outside of Docker container

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -14,5 +14,12 @@ if missing pre-commit; then
 fi
 # If installed, it executes very fast
 pre-commit install
+# Convenient if you want secrets to load  (e.g. personal token, Github webhook secret)
+dotenv_if_exists .env
+# This enables development outside of the Docker container
+dotenv env.development
 
 echo "${green}${bold}SUCCESS!${reset}"
+
+# shellcheck disable=SC2006
+echo "You can either call docker-compose up or flask run (useful for using pdb)"

--- a/env.development
+++ b/env.development
@@ -1,0 +1,8 @@
+# These env variables enable running the Flask app outside of the Docker container
+# thus, allowing for using the Python debugger easily
+FLASK_APP=deployhook.py
+FLASK_ENV=development
+FLASK_RUN_HOST=0.0.0.0
+DRY_RUN=True
+# You can point to a different repo but you will need bin/bump-sentry and cloudbuild.yaml from getsentry
+DEPLOY_REPO=getsentry/getsentry-test-repo


### PR DESCRIPTION
This makes it easier to run flask outside of the Docker container, thus, being able to
use Python's debugger.

It is possible to use the Python debugger with Docker, however, it takes a bit more set up work.