### PR TITLE
feat: Switch from cmd to run for deeper insight

### DIFF
--- a/deployhook.py
+++ b/deployhook.py
@@ -103,8 +103,7 @@ def bump_version(branch, bump_args=[]):
             successful_push = True
             break
         except CommandError as e:
-            continue
-        run(f"git pull --rebase origin {branch}", cwd=repo_root)
+            run(f"git pull --rebase origin {branch}", cwd=repo_root)
 
     if not successful_push:
         return False, "Failed to push."


### PR DESCRIPTION
The `run` function is superior in that it captures the output of the command and reports it to Sentry.

The main beneficial feature of the `run()` method is that it always raises an exception rather than requiring the developer to check the error code or the output.

This example shows how we explicitly have to check for the return code to become aware of any problems.
https://github.com/getsentry/gitbot/blob/6b5e6bbc7c30bc095ff49d57dd3ba2e89f687a05/deployhook.py#L84-L95

This is why this code failed on #33 and it went unnoticed by Sentry: https://github.com/getsentry/gitbot/blob/6b5e6bbc7c30bc095ff49d57dd3ba2e89f687a05/deployhook.py#L101 

Fixes #33