### PR TITLE
feat: Increase timeout and transport queue for reporting to Sentry

### DIFF
--- a/gitbot/deployhook.py
+++ b/gitbot/deployhook.py
@@ -13,6 +13,14 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from gitbot.config import *
 from gitbot.lib import *
 
+logging.basicConfig(
+    level=LOGGING_LEVEL,
+    # GCR logs already include the time
+    format="%(message)s" if ENV == "development" else "%(levelname)-8s %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
 
 def boot():
     if ENV != "development":
@@ -216,20 +224,8 @@ def valid_payload(secret: str, payload: str, signature: str) -> bool:
     return hmac.compare_digest(payload_signature, signature)
 
 
-logging.basicConfig(
-    level=LOGGING_LEVEL,
-    # GCR logs already include the time
-    format="%(message)s" if ENV == "development" else "%(levelname)-8s %(message)s",
-    datefmt="%H:%M:%S",
-)
-logger = logging.getLogger(__name__)
-try:
-    boot()
-    app = Flask(__name__)
-except Exception as e:
-    sentry_sdk.capture_exception(e)
-    logger.exception(e)
-    raise (e)
+boot()
+app = Flask(__name__)
 
 
 @app.route("/", methods=["POST"])


### PR DESCRIPTION
When an error is not caught at the top level, the worker is only given a bit
of time to report the error before shutting down.

In order to report the error to Sentry we need to capture first, report it
and then re-raise it for the worker to fail and shut down.

<img width="941" alt="image" src="https://user-images.githubusercontent.com/44410/129772365-c36ff07b-d52e-47d6-850b-8d6f6b737676.png">
