### PR TITLE
ref: upgrade check-jsonschema so it does not reach network at runtime

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.3.1
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.16.0
     hooks:
       - id: check-github-workflows
   - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
the latest version of `check-jsonschema` vendors the github actions and workflows schemas rather than reaching out to the network to download them each time -- this should reduce flakiness of this check

Committed via https://github.com/asottile/all-repos