### PR TITLE
feat: new frozen bump-sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 venv
+.venv
 *.pyc
 *.pyo
 gcr-key.json

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ google-cloud-secret-manager==2.4.0
 gunicorn==20.0.4
 Flask==2.1.2
 sentry-sdk[flask]==1.1.0
+pip-tools==6.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,12 +18,15 @@ grpc-google-iam-v1==0.12.4
 grpcio==1.46.3
 gunicorn==20.0.4
 idna==3.3
+importlib-metadata==4.12.0
 itsdangerous==2.1.2
 jinja2==3.1.2
 libcst==0.4.4
 markupsafe==2.1.1
 mypy-extensions==0.4.3
 packaging==21.3
+pep517==0.12.0
+pip-tools==6.6.2
 proto-plus==1.20.6
 protobuf==3.20.1
 pyasn1==0.4.8
@@ -35,10 +38,14 @@ requests==2.28.0
 rsa==4.8
 sentry-sdk[flask]==1.1.0
 six==1.16.0
+tomli==2.0.1
 typing-extensions==4.2.0
 typing-inspect==0.7.1
 urllib3==1.26.9
 werkzeug==2.1.2
+wheel==0.37.1
+zipp==3.8.0
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
We just need to make sure pip-tools is installed, but not sure yet how to test with https://github.com/getsentry/getsentry-test-repo.