### PR TITLE
fix bump check for sentry-version file

### DIFF
--- a/bump.py
+++ b/bump.py
@@ -1,11 +1,13 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script is called in getsentry's gitbot.yml to ensure the integration between the two
+from __future__ import annotations
+
 import argparse
 import logging
-import os
 import shutil
 from tempfile import mkdtemp
+from typing import Sequence
 
 from gitbot.lib import bump_version, run
 
@@ -18,53 +20,49 @@ def validate_bump(result: bool, text: str, tmpdir: str) -> None:
     assert text == "Executed: bin/bump-sentry ccc86db8a6a2541b5786f76e8461f587a8adca20"
     execution = run("git show -s --oneline", tmpdir)
     assert (
-        execution.stdout.find(
-            "getsentry/sentry@ccc86db8a6a2541b5786f76e8461f587a8adca20"
-        )
-        > -1
-    )
+        "getsentry/sentry@ccc86db8a6a2541b5786f76e8461f587a8adca20" in execution.stdout
+    ), execution.stdout
     execution = run("git grep ccc86db8a6a2541b5786f76e8461f587a8adca20", tmpdir)
     split_lines = execution.stdout.splitlines()
-    assert len(split_lines) == 4
-    for line in split_lines:
-        assert (
-            line.find("SENTRY_VERSION_SHA=ccc86db8a6a2541b5786f76e8461f587a8adca20")
-            > -1
-        )
+    assert split_lines == [
+        "cloudbuild.yaml:            '--build-arg', 'SENTRY_VERSION_SHA=ccc86db8a6a2541b5786f76e8461f587a8adca20',",
+        "docker/frontend_cloudbuild.yaml:      '--build-arg', 'SENTRY_VERSION_SHA=ccc86db8a6a2541b5786f76e8461f587a8adca20',",
+        "sentry-version:ccc86db8a6a2541b5786f76e8461f587a8adca20",
+    ], split_lines
 
 
-def main(branch: str, getsentry_path: str) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--branch",
+        required=True,
+        help="Branch to clone.",
+    )
+    parser.add_argument(
+        "--getsentry-path",
+        required=True,
+        help="Path to getsentry checkout.",
+    )
+    args = parser.parse_args(argv)
     tmpdir = mkdtemp()
     try:
         # raise Exception()
         # We make a soft clone of it into a tempdir and then try to bump
         result, text = bump_version(
-            branch=branch,
+            branch=args.branch,
             ref_sha="ccc86db8a6a2541b5786f76e8461f587a8adca20",  # Random sha from Sentry repo
-            url=getsentry_path,  # It will soft clone
+            url=args.getsentry_path,  # It will soft clone
             dry_run=True,  # This will prevent trying to push
             temp_checkout=tmpdir,  # We pass this value in order to inspect what happened
         )
         validate_bump(result, text, tmpdir)
     finally:
         # This undoes what bump version did
-        run("git config --unset user.name", cwd=getsentry_path, raise_error=False)
-        run("git config --unset user.email", cwd=getsentry_path, raise_error=False)
+        run("git config --unset user.name", cwd=args.getsentry_path, raise_error=False)
+        run("git config --unset user.email", cwd=args.getsentry_path, raise_error=False)
         shutil.rmtree(tmpdir)
     return 0
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--branch",
-        type=str,
-        help="Branch to clone.",
-    )
-    parser.add_argument(
-        "--getsentry-path",
-        type=str,
-        help="Path to getsentry checkout.",
-    )
-    args = parser.parse_args()
-    raise SystemExit(main(args.branch, os.path.abspath(args.getsentry_path)))
+    raise SystemExit(main())


### PR DESCRIPTION
testing done:

```console
$ python3 -m bump --branch asottile-wat --getsentry-path $PWD/../getsentry
INFO:gitbot.lib:>  git clone --depth 1 -b asottile-wat /home/asottile/workspace/gitbot/../getsentry /tmp/tmpayvywz3l (cwd: /tmp/tmpayvywz3l)
INFO:gitbot.lib:Cloning into '/tmp/tmpayvywz3l'...
INFO:gitbot.lib:warning: --depth is ignored in local clones; use file:// instead.
INFO:gitbot.lib:done.
INFO:gitbot.lib:>  git config user.name Sentry Bot (cwd: /tmp/tmpayvywz3l)
INFO:gitbot.lib:>  git config user.email bot@sentry.io (cwd: /tmp/tmpayvywz3l)
INFO:gitbot.lib:>  bin/bump-sentry ccc86db8a6a2541b5786f76e8461f587a8adca20 (cwd: /tmp/tmpayvywz3l)
INFO:gitbot.lib:[asottile-wat 839f822363] getsentry/sentry@ccc86db8a6a2541b5786f76e8461f587a8adca20
INFO:gitbot.lib: 4 files changed, 15 insertions(+), 14 deletions(-)
INFO:gitbot.lib:>  git push origin --dry-run asottile-wat (cwd: /tmp/tmpayvywz3l)
INFO:gitbot.lib:To /home/asottile/workspace/gitbot/../getsentry
INFO:gitbot.lib:   6d55f01f25..839f822363  asottile-wat -> asottile-wat
INFO:gitbot.lib:>  git show -s --oneline (cwd: /tmp/tmpayvywz3l)
INFO:gitbot.lib:839f822363 getsentry/sentry@ccc86db8a6a2541b5786f76e8461f587a8adca20
INFO:gitbot.lib:>  git grep ccc86db8a6a2541b5786f76e8461f587a8adca20 (cwd: /tmp/tmpayvywz3l)
INFO:gitbot.lib:cloudbuild.yaml:            '--build-arg', 'SENTRY_VERSION_SHA=ccc86db8a6a2541b5786f76e8461f587a8adca20',
INFO:gitbot.lib:docker/frontend_cloudbuild.yaml:      '--build-arg', 'SENTRY_VERSION_SHA=ccc86db8a6a2541b5786f76e8461f587a8adca20',
INFO:gitbot.lib:sentry-version:ccc86db8a6a2541b5786f76e8461f587a8adca20
INFO:gitbot.lib:>  git config --unset user.name (cwd: /home/asottile/workspace/gitbot/../getsentry)
INFO:gitbot.lib:>  git config --unset user.email (cwd: /home/asottile/workspace/gitbot/../getsentry)
$ echo $?
0
```