### PR TITLE
ensure getsentry_path is absolute

### DIFF
--- a/bump.py
+++ b/bump.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os.path
 import shutil
 from tempfile import mkdtemp
 from typing import Sequence
@@ -44,6 +45,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Path to getsentry checkout.",
     )
     args = parser.parse_args(argv)
+    args.getsentry_path = os.path.abspath(args.getsentry_path)
     tmpdir = mkdtemp()
     try:
         # raise Exception()


### PR DESCRIPTION
and one more fix:

testing done (note the relative path):

```console
$ python3 -m bump --branch asottile-wat --getsentry-path ../getsentry
INFO:gitbot.lib:>  git clone --depth 1 -b asottile-wat /home/asottile/workspace/getsentry /tmp/tmpb70lpggb (cwd: /tmp/tmpb70lpggb)
INFO:gitbot.lib:Cloning into '/tmp/tmpb70lpggb'...
INFO:gitbot.lib:warning: --depth is ignored in local clones; use file:// instead.
INFO:gitbot.lib:done.
INFO:gitbot.lib:>  git config user.name Sentry Bot (cwd: /tmp/tmpb70lpggb)
INFO:gitbot.lib:>  git config user.email bot@sentry.io (cwd: /tmp/tmpb70lpggb)
INFO:gitbot.lib:>  bin/bump-sentry ccc86db8a6a2541b5786f76e8461f587a8adca20 (cwd: /tmp/tmpb70lpggb)
INFO:gitbot.lib:[asottile-wat e751090b82] getsentry/sentry@ccc86db8a6a2541b5786f76e8461f587a8adca20
INFO:gitbot.lib: 4 files changed, 15 insertions(+), 14 deletions(-)
INFO:gitbot.lib:>  git push origin --dry-run asottile-wat (cwd: /tmp/tmpb70lpggb)
INFO:gitbot.lib:To /home/asottile/workspace/getsentry
INFO:gitbot.lib:   6d55f01f25..e751090b82  asottile-wat -> asottile-wat
INFO:gitbot.lib:>  git show -s --oneline (cwd: /tmp/tmpb70lpggb)
INFO:gitbot.lib:e751090b82 getsentry/sentry@ccc86db8a6a2541b5786f76e8461f587a8adca20
INFO:gitbot.lib:>  git grep ccc86db8a6a2541b5786f76e8461f587a8adca20 (cwd: /tmp/tmpb70lpggb)
INFO:gitbot.lib:cloudbuild.yaml:            '--build-arg', 'SENTRY_VERSION_SHA=ccc86db8a6a2541b5786f76e8461f587a8adca20',
INFO:gitbot.lib:docker/frontend_cloudbuild.yaml:      '--build-arg', 'SENTRY_VERSION_SHA=ccc86db8a6a2541b5786f76e8461f587a8adca20',
INFO:gitbot.lib:sentry-version:ccc86db8a6a2541b5786f76e8461f587a8adca20
INFO:gitbot.lib:>  git config --unset user.name (cwd: /home/asottile/workspace/getsentry)
INFO:gitbot.lib:>  git config --unset user.email (cwd: /home/asottile/workspace/getsentry)
$ echo $?
0
```