### PR TITLE
fix: hotfix #1, do not shallow clone from /tmp/sentry rather just symlink it into bump getsentry tmpdir

### DIFF
--- a/gitbot/lib.py
+++ b/gitbot/lib.py
@@ -170,10 +170,10 @@ def bump_version(
         # redist. dev environments.
         try:
             run(
-                f"git clone --depth 1 -b master {sentry_path} {repo_root}/../sentry",
+                f"ln -sf {sentry_path} {repo_root}/../sentry",
             )
-        except CommandError:
-            return False, f"Cannot clone branch feat/frozen-dependencies from {sentry_path}."
+        except CommandError as e:
+            return False, f"Error: {e}"
 
         run(f"git config user.name {COMMITTER_NAME}", cwd=repo_root)
         run(f"git config user.email {COMMITTER_EMAIL}", cwd=repo_root)


### PR DESCRIPTION
We clone getsentry to a tmpdir, but need the full updated clone of sentry which is maintained in SENTRY_CHECKOUT_PATH. This was fine during manual testing but won't work in production.

https://sentry.io/organizations/sentry/issues/2677689153/?project=5748916&query=is%3Aunresolved&statsPeriod=24h

```
`('git', '-C', '../sentry', 'show', 'f6573e10776918ed83fbeb734c42f15ad16ea532:requirements-frozen.txt')` returned code 128

stdout:


stderr:
fatal: path 'requirements-frozen.txt' does not exist in 'f6573e10776918ed83fbeb734c42f15ad16ea532'
```