### PR TITLE
feat(repo_url): RepoUrl class to prevent accidental secret leaks

### DIFF
--- a/gitbot/config.py
+++ b/gitbot/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from models import RepoUrl
 
 LOGGING_LEVEL = os.environ.get("LOGGING_LEVEL", logging.INFO)
 logger = logging.getLogger(__name__)
@@ -11,11 +12,13 @@ def fetch_secret(client: "secretmanager.SecretManagerService", uri: str) -> str:
     return client.access_secret_version(name=uri).payload.data.decode("UTF-8")
 
 
-def repo_url(repo: str) -> str:
+def repo_url(repo: str) -> RepoUrl:
     if PAT:
-        return f"https://{os.environ.get('GITBOT_USER', 'getsentry-bot')}:{PAT}@github.com/{repo}"
+        return RepoUrl(
+            repo=repo, user=os.environ.get("GITBOT_USER", "getsentry-bot"), pat=PAT
+        )
     else:
-        return f"git@github.com:/{repo}"
+        return RepoUrl(repo=repo)
 
 
 COMMITTER_NAME = "Sentry Bot"
@@ -53,7 +56,6 @@ if os.environ.get("K_SERVICE") and not os.environ.get("FAST_STARTUP"):
     GITBOT_API_SECRET = fetch_secret(
         client, "projects/sentry-dev-tooling/secrets/GitbotSecret/versions/1"
     )
-
 
 # Repo related constants
 GETSENTRY_BRANCH = "master"

--- a/gitbot/config.py
+++ b/gitbot/config.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from models import RepoUrl
+from gitbot.models import RepoUrl
 
 LOGGING_LEVEL = os.environ.get("LOGGING_LEVEL", logging.INFO)
 logger = logging.getLogger(__name__)

--- a/gitbot/lib.py
+++ b/gitbot/lib.py
@@ -7,7 +7,7 @@ import shlex
 import subprocess
 import tempfile
 from typing import Any
-from models import RepoUrl
+from gitbot.models import RepoUrl
 
 from gitbot.config import (
     COMMITTER_EMAIL,

--- a/gitbot/models.py
+++ b/gitbot/models.py
@@ -1,0 +1,48 @@
+from typing import Optional, Any
+
+
+class RepoUrl:
+    """Represents a repository URL with some protections to avoid leaking secrets
+
+    Shamelessly pulled and adapted from pydantic <3
+    https://github.com/pydantic/pydantic/blob/ea870115b71c3c8843f454989d0ccffe3edc0279/pydantic/types.py#L801-L848
+
+
+    """
+
+    def __init__(
+        self, repo: str, user: Optional[str] = None, pat: Optional[str] = None
+    ):
+        if pat and user:
+            self._secret_value = f"https://{user}:{pat}@github.com/{repo}"
+            self.has_pat = True
+            self._pat = pat
+            self._user = user
+            self._repo = repo
+        else:
+            self._secret_value = f"git@github.com:/{repo}"
+            self.has_pat = False
+
+    def __str__(self) -> str:
+        if not self._secret_value:
+            return ""
+
+        if self.has_pat:
+            return f"https://{self._user}:**REDACTED**@github.com/{self._repo}"
+        else:
+            return f"git@github.com:/{self._repo}"
+
+    def __repr__(self) -> str:
+        return f"RepoUrl('{self}')"
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, RepoUrl)
+            and self.get_secret_value() == other.get_secret_value()
+        )
+
+    def get_secret_value(self) -> str:
+        """
+        Returns the secret value as a plaintext string. Careful not to leak it!
+        """
+        return self._secret_value

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,45 @@
+from gitbot.models import RepoUrl
+
+
+def test_redacted_repo_url_with_pat():
+    pat = "NotAnActualPAT1234"
+    repo_url = RepoUrl(repo="getsentry/random-repo", user="username", pat=pat)
+
+    expected_str = "https://username:**REDACTED**@github.com/getsentry/random-repo"
+
+    assert expected_str == f"{repo_url}"
+    assert pat not in f"{repo_url}"
+
+
+def test_repo_url_secret_value():
+    pat = "NotAnActualPAT1234"
+    repo_url = RepoUrl(repo="getsentry/random-repo", user="username", pat=pat)
+
+    expected_str = (
+        "https://username:NotAnActualPAT1234@github.com/getsentry/random-repo"
+    )
+
+    assert expected_str == f"{repo_url.get_secret_value()}"
+
+
+def test_repo_url_eq():
+    repo_url_2 = RepoUrl(
+        repo="getsentry/random-repo", user="username", pat="NotAnActualPAT1234"
+    )
+    repo_url_1 = RepoUrl(
+        repo="getsentry/random-repo", user="username", pat="NotAnActualPAT1234"
+    )
+
+    assert repo_url_1 == repo_url_2
+
+
+def test_repo_url_not_eq():
+    repo_url_2 = RepoUrl(
+        repo="getsentry/random-repo-1", user="username", pat="NotAnActualPAT1234"
+    )
+
+    repo_url_1 = RepoUrl(
+        repo="getsentry/random-repo", user="username", pat="NotAnActualPAT1234"
+    )
+
+    assert repo_url_1 != repo_url_2


### PR DESCRIPTION
Instead of representing the repository URL as a standard string,
this PR introduces a `RepoUrl` class. 

Repo URLs can contain sensitive values. Using the `RepoUrl` class can prevent leaking the secret values
by overloading the `__str__` and `__repr__` methods.

To retrieve the actual secret value, call `.get_secret_value()`.

[Adapted and inspired from `pydantic`'s `SecretStr`.]( https://github.com/pydantic/pydantic/blob/ea870115b71c3c8843f454989d0ccffe3edc0279/pydantic/types.py#L801-L848) ❤️ 
   