### PR TITLE
Update getsentry/action-release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
           region: us-central1
 
       - name: Sentry Release
-        uses: getsentry/action-release@v1.1.5
+        uses: getsentry/action-release@v1.2.1
         # If we want to compare a release from a deployed PR we should report it, otherwise,
         # it would only show up in the Sentry SaaS if an error occurred
         with:


### PR DESCRIPTION
This change addresses the set-ouput and save state deprecation by GitHub. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Committed via https://github.com/asottile/all-repos